### PR TITLE
Reject estimates with dates in the future (closes #6)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ def version
   Gem::Specification.load(Dir['*.gemspec'].first).version
 end
 
-task default: [:clean, :test, :features, :rubocop, :copyright]
+task default: [:clean, :test, :features, :rubocop]
 
 require 'rake/testtask'
 desc 'Run all unit tests'

--- a/lib/est/estimate.rb
+++ b/lib/est/estimate.rb
@@ -20,6 +20,7 @@ module Est
     def initialize(file)
       @yaml = YAML.load_file(file)
       fail "failed to read file #{file}" unless @yaml
+      fail "date #{date} is in the future" if date > Date.today
     end
 
     # Get date.

--- a/test/test_estimate.rb
+++ b/test/test_estimate.rb
@@ -50,4 +50,28 @@ class TestEstimate < Minitest::Test
       assert_equal 79, estimate.total
     end
   end
+
+  def test_rejects_future_date
+    Dir.mktmpdir 'test' do |dir|
+      file = File.join(dir, 'future.est')
+      future = (Date.today + 365).strftime('%d-%m-%Y')
+      File.write(
+        file,
+        "
+        date: #{future}
+        author: Marty McFly
+        method: champions.pert
+        scope:
+          1: basic Sinatra scaffolding
+          2: front-end HAML files
+        champions:
+          2:
+            worst-case: 30
+            best-case: 8
+            most-likely: 16
+        "
+      )
+      assert_raises(RuntimeError) { Est::Estimate.new(file) }
+    end
+  end
 end


### PR DESCRIPTION
@yegor256 — this PR closes #6: it makes `Est::Estimate` reject estimate files whose `date` field points past today, instead of silently accepting them.

## Summary

- `lib/est/estimate.rb` — `Est::Estimate#initialize` now fails fast with `"date <D> is in the future"` when the parsed `date` is greater than `Date.today`. Existing past-dated estimates are unaffected.
- `test/test_estimate.rb` — adds `test_rejects_future_date`, which writes a YAML estimate dated `Date.today + 365` and asserts that constructing `Est::Estimate` raises. Without the fix this test fails (the estimate is silently accepted); with the fix it passes.
- `Rakefile` — drops the dangling `:copyright` prerequisite from the `default` task. The `:copyright` task itself was removed in cdf4bb4 ("copyright task removed") but the reference in the default list was left behind, so `bundle exec rake` aborted with "Don't know how to build task 'copyright'" before any test could run. This was a prerequisite for verifying the fix locally.

## Verification

Locally, `bundle exec rake test` goes from 5 → 6 runs, all green:

```
6 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```

## CI status

Pre-existing failures on `master` that are unrelated to this change and remain unchanged on this branch: `rake` (cucumber 2.99.0 calls the removed 3-arg `ERB.new` API and fails to parse `cucumber.yml` under Ruby 3.3), `codecov` (same root cause via `bundle exec rake`), `markdown-lint` (MD014/MD041 in `README.md`), `yamllint` (indentation in `.rultor.yml`), and `copyrights`. Each of these fails identically on `master` (e.g. run 25281149105) and on this branch (run 25577645220), so this PR introduces no regressions; fixing them is out of scope for #6 and likely warrants separate PRs.